### PR TITLE
fix: resolve issues #8, #10, #11

### DIFF
--- a/src/audit/config-loader.ts
+++ b/src/audit/config-loader.ts
@@ -25,12 +25,14 @@ export function getStateDir(): string {
   return join(homedir(), ".openclaw");
 }
 
-/** Strip comments and trailing commas from JSON5-like config (simple parser) */
+/** Strip comments and trailing commas from JSON5-like config (string-aware) */
 function sanitizeJson5(text: string): string {
-  // Remove single-line comments (// ...)
-  let result = text.replace(/\/\/[^\n]*/g, "");
-  // Remove multi-line comments (/* ... */)
-  result = result.replace(/\/\*[\s\S]*?\*\//g, "");
+  // Match string literals first to preserve their content, then strip comments.
+  // Order of alternation matters: strings are matched before comment tokens.
+  let result = text.replace(
+    /"(?:[^"\\]|\\.)*"|\/\/[^\n]*|\/\*[\s\S]*?\*\//g,
+    (match) => (match.startsWith('"') ? match : "")
+  );
   // Remove trailing commas before } or ]
   result = result.replace(/,(\s*[}\]])/g, "$1");
   return result;

--- a/src/forensic/redact.ts
+++ b/src/forensic/redact.ts
@@ -35,20 +35,6 @@ function redactString(original: string): string {
   return original.slice(0, 2) + "*".repeat(original.length - 4) + original.slice(-2);
 }
 
-/** Apply redaction to content string */
-function redactInContent(content: string, matchPreview: string): string {
-  // The matchPreview is already redacted (e.g., "+1********61")
-  // We need to find the original pattern and redact it
-  // Since we don't have the original, we'll use a heuristic:
-  // Find strings that match the redaction pattern
-  
-  // For now, use a simple approach: find patterns that could match
-  // This works because the violation's position is relative to the message content
-  
-  // Actually, we need to be smarter. Let's use regex patterns based on rule type
-  return content;
-}
-
 /** Parse JSONL file */
 function parseJsonl(text: string): JsonlEntry[] {
   const entries: JsonlEntry[] = [];
@@ -130,7 +116,10 @@ const REDACTION_PATTERNS: Record<string, RegExp[]> = {
 /** Apply redaction to a message's content for a specific rule */
 function redactContent(content: string, ruleId: string): string {
   const patterns = REDACTION_PATTERNS[ruleId];
-  if (!patterns) return content;
+  if (!patterns) {
+    console.warn(`[lobstercage] No redaction pattern for rule "${ruleId}" — content left unchanged`);
+    return content;
+  }
 
   let result = content;
   for (const pattern of patterns) {

--- a/src/stats/storage.ts
+++ b/src/stats/storage.ts
@@ -115,33 +115,39 @@ function updateDailySummary(
   }
 }
 
+/** Serializes concurrent recordScanEvent calls to prevent lost-update races */
+let _statsLock: Promise<void> = Promise.resolve();
+
 /** Record a new scan event */
 export async function recordScanEvent(
   type: "forensic" | "guard" | "audit" | "skill-scan" | "integrity" | "install-safe",
   violations: ViolationEvent[]
 ): Promise<void> {
-  const stats = await loadStats();
+  _statsLock = _statsLock.then(async () => {
+    const stats = await loadStats();
 
-  const event: ScanEvent = {
-    id: randomUUID(),
-    timestamp: new Date().toISOString(),
-    type,
-    violations,
-  };
+    const event: ScanEvent = {
+      id: randomUUID(),
+      timestamp: new Date().toISOString(),
+      type,
+      violations,
+    };
 
-  stats.events.push(event);
-  stats.dailySummaries = updateDailySummary(stats.dailySummaries, violations);
+    stats.events.push(event);
+    stats.dailySummaries = updateDailySummary(stats.dailySummaries, violations);
 
-  // Prune old events (keep last 90 days)
-  const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - 90);
-  const cutoffStr = cutoff.toISOString();
-  stats.events = stats.events.filter((e) => e.timestamp >= cutoffStr);
-  stats.dailySummaries = stats.dailySummaries.filter(
-    (s) => s.date >= cutoffStr.slice(0, 10)
-  );
+    // Prune old events (keep last 90 days)
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - 90);
+    const cutoffStr = cutoff.toISOString();
+    stats.events = stats.events.filter((e) => e.timestamp >= cutoffStr);
+    stats.dailySummaries = stats.dailySummaries.filter(
+      (s) => s.date >= cutoffStr.slice(0, 10)
+    );
 
-  await saveStats(stats);
+    await saveStats(stats);
+  });
+  return _statsLock;
 }
 
 /** Get stats for last N days */


### PR DESCRIPTION
Closes #8
Closes #10
Closes #11

## Summary

- **#8 – redactInContent() no-op stub**: Removed the dead `redactInContent()` function that returned content unchanged. Added a `console.warn` in `redactContent()` when no pattern exists for a `ruleId`, so operators are alerted instead of PII silently passing through.

- **#10 – sanitizeJson5 URL corruption**: Rewrote the comment-stripping regex with a string-aware alternation (`"..."|//...|/*...*/`). String literals are now matched first and preserved; only tokens outside strings are stripped. Fixes corruption of URLs like `https://example.com` and Windows paths.

- **#11 – stats race condition**: Serialized `recordScanEvent()` via a module-level promise-chain mutex (`_statsLock`). All concurrent calls are queued and executed one at a time, ensuring atomic read-modify-write semantics without adding external dependencies.

## Test plan
- `npm test` — 34 tests passed (all existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)